### PR TITLE
add umami tracking

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -39,6 +39,11 @@ export default async function RootLayout({
         />
         <link rel="manifest" href="/site.webmanifest" />
         <link rel="dns-prefetch" href="https://api.podcastindex.org" />
+        <script
+          defer
+          src={process.env.NEXT_PUBLIC_UMAMI_SRC}
+          data-website-id={process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID}
+        ></script>
       </head>
       <body>
         <Header />

--- a/src/components/downloadPodcastButton.tsx
+++ b/src/components/downloadPodcastButton.tsx
@@ -111,7 +111,7 @@ export const DownloadPodcastButton = ({
     downloading: undefined,
     downloaded: handleDownload,
     downloadOnDesktop: undefined,
-    downloadedInNewTab: undefined,
+    downloadedInNewTab: handleDownload,
   };
 
   if (downloadState === DownloadState.downloadedInNewTab) {
@@ -124,6 +124,7 @@ export const DownloadPodcastButton = ({
             disabled
             aria-disabled
             aria-label={buttonAriaLabel[downloadState]}
+            onClick={handleOnClick[downloadState]}
           >
             {downloadIcon[downloadState]}
             Downloaded in new tab - click to retry
@@ -150,6 +151,11 @@ export const DownloadPodcastButton = ({
         downloadState === DownloadState.DownloadOnDesktop
       }
       aria-label={buttonAriaLabel[downloadState]}
+      data-umami-event={
+        downloadState === DownloadState.ReadyToDownload
+          ? 'Download podcast'
+          : undefined
+      }
     >
       {downloadIcon[downloadState]}
       {downloadState === DownloadState.ReadyToDownload && 'Download'}


### PR DESCRIPTION
This pull request introduces changes to enhance analytics tracking and improve the functionality of the `DownloadPodcastButton` component. The most important changes include adding Umami analytics tracking to the application and refining the download button's behavior to handle additional states and interactions.

### Analytics Tracking Enhancements:
* [`src/app/layout.tsx`](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R42-R46): Added a deferred script to include Umami analytics, using environment variables for the script source and website ID.

### `DownloadPodcastButton` Improvements:
* [`src/components/downloadPodcastButton.tsx`](diffhunk://#diff-f4b16ff3fb0ed03bca74595f30b3a57a70ae20d1dc7dcd2e145aeed70aa7c2f3L114-R114): Updated the `downloadedInNewTab` state to use the `handleDownload` function, ensuring consistent behavior across states.
* [`src/components/downloadPodcastButton.tsx`](diffhunk://#diff-f4b16ff3fb0ed03bca74595f30b3a57a70ae20d1dc7dcd2e145aeed70aa7c2f3R127): Added an `onClick` handler for the button, dynamically determined by the current download state, to improve interaction handling.
* [`src/components/downloadPodcastButton.tsx`](diffhunk://#diff-f4b16ff3fb0ed03bca74595f30b3a57a70ae20d1dc7dcd2e145aeed70aa7c2f3R154-R158): Introduced a `data-umami-event` attribute to track download events when the button is in the `ReadyToDownload` state.